### PR TITLE
warning nach installation verhindern

### DIFF
--- a/lib/iwcc_frontend.php
+++ b/lib/iwcc_frontend.php
@@ -21,6 +21,7 @@ class iwcc_frontend
 
     public function setDomain($domain)
     {
+        if (!isset($this->cache['domains'])) return;
         foreach ($this->cache['domains'] as $k => $v)
         {
             if ($v['uid'] == $domain)


### PR DESCRIPTION
der cache wird beim speichern der backend formulare geschrieben, steht deswegen direkt nach der installation nicht zur verfuegung
https://github.com/FriendsOfREDAXO/iwcc/issues/65