### PR TITLE
bugfix id -> pid

### DIFF
--- a/lib/iwcc_rex_form.php
+++ b/lib/iwcc_rex_form.php
@@ -81,7 +81,7 @@ class iwcc_rex_form
     {
         $db = rex_sql::factory();
         $db->setTable(rex::getTable('iwcc_cookiegroup'));
-        $db->setWhere('id=' . $groupId);
+        $db->setWhere('pid=' . $groupId);
         $db->select('uid,domain');
         $group = $db->getArray()[0];
         if ($group['domain'])


### PR DESCRIPTION
die pid wurde fälschlicherweise mit der id abgeglichen. Sobald eine Cookie-Gruppe gelöscht und eine neue angelegt wurde, war pid != id und es gab ein notice sowie einen Fehler im select "Reihenfolge"

