### PR TITLE
Update fontello.css

### DIFF
--- a/assets/fontello/css/fontello.css
+++ b/assets/fontello/css/fontello.css
@@ -20,7 +20,7 @@
 }
 */
  
- [class^="icon-"]:before, [class*=" icon-"]:before {
+#iwcc-wrapper [class^="icon-"]:before, #iwcc-wrapper [class*=" icon-"]:before {
   font-family: "fontello";
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
Fontello Iconschrift auf IWCC AddOn beschränken um Konflikt mit Webseiten-Icons zu verhindern.