### PR TITLE
 Erweiterung um Fragment "Aktuell gesetzte Cookies" (2)

### DIFF
--- a/fragments/iwcc_cookiedb.php
+++ b/fragments/iwcc_cookiedb.php
@@ -1,61 +1,147 @@
 <?php
 $iwcc = new iwcc_frontend($this->getVar('forceCache'));
 $iwcc->setDomain($_SERVER['HTTP_HOST']);
-if ($this->getVar('debug'))
-{
+if ($this->getVar('debug')) {	
+    dump($iwcc);
 	print_r($_COOKIE);
 }
 
-if ($iwcc->cookiegroups) {
+$output = '';
 
-	$cookieDatabase = array();
+if ($iwcc->cookiegroups) {
 	
+	// Cookie Consent + History
+	$iwcc_cookie = isset($_COOKIE['iwcc']) ? json_decode($_COOKIE['iwcc'],1) : false;
+	if ($iwcc_cookie) {
+		
+		$db = rex_sql::factory();
+		$db->setDebug(false);
+		$db->setQuery('SELECT '.rex::getTable('iwcc_consent_log').'.* 
+						FROM '.rex::getTable('iwcc_consent_log').' 
+						WHERE '.rex::getTable('iwcc_consent_log').'.cachelogid = :cachelogid
+						ORDER BY '.rex::getTable('iwcc_consent_log').'.id DESC
+						LIMIT 5'						
+						,['cachelogid'=>$iwcc_cookie['cachelogid']]
+					);
+		$history = $db->getArray();
+		
+		$consents = json_decode($history[0]['consents']);
+		//$consents_uids_output = implode(', ', $consents);
+		$consents_service_names = array();
+		foreach($consents as $consent) {
+			$consents_service_names[] = $iwcc->cookies[$consent]['service_name'].' ('.$consent.')';
+		}
+		$consents_uids_output = implode(', ', $consents_service_names);
+		
+		$output .= '<h2>'.$iwcc->texts['headline_currentconsent'].'</h2>';
+		$output .= '<p class="iwcc-hisotry-date"><span>'.$iwcc->texts['consent_date'].':</span> '.$history[0]['createdate'].'</p>';		
+		$output .= '<p class="iwcc-hisotry-id"><span>'.$iwcc->texts['consent_id'].':</span> '.$history[0]['consentid'].'</p>';
+		$output .= '<p class="iwcc-hisotry-consents"><span>'.$iwcc->texts['consent_consents'].':</span> '.$consents_uids_output.'</p>';
+		$output .= '<p><a class="iwcc-show-box">'.$iwcc->texts['edit_consent'].'</a></p>'; // mit iwcc-show-box-reload funktionierts nicht korrekt
+		
+		$output .= '<h2>'.$iwcc->texts['headline_historyconsent'].'</h2>';
+		$output .= '<table class="iwcc-historytable">';
+		$output .= '<tr>
+						<th class="iwcc-hisotry-date">'.$iwcc->texts['consent_date'].'</th>
+						<th class="iwcc-hisotry-id">'.$iwcc->texts['consent_id'].'</th>
+						<th class="iwcc-hisotry-consents">'.$iwcc->texts['consent_consents'].'</th>
+					</tr>';
+		foreach ($history as $historyentry) {	
+			$consents = json_decode($historyentry['consents']);
+			//$consents_uids_output = implode(', ', $consents);
+			$consents_service_names = array();
+			foreach($consents as $consent) {
+				$consents_service_names[] = $iwcc->cookies[$consent]['service_name'].' ('.$consent.')';
+			}
+			$consents_uids_output = implode(', ', $consents_service_names);
+			$output .= '<tr>';
+			$output .= '<td class="iwcc-hisotry-date">'.$historyentry['createdate'].'</td>';		
+			$output .= '<td class="iwcc-hisotry-id">'.$historyentry['consentid'].'</td>';
+			$output .= '<td class="iwcc-hisotry-consents">'.$consents_uids_output.'</td>';
+			$output .= '</tr>';
+		}
+		$output .= '</table>';
+	}
+	
+	// Cookies We May Use
+	
+	$output .= '<hr>';
+	$output .= '<h2>'.$iwcc->texts['headline_mayusedcookies'].'</h2>';
+
 	foreach ($iwcc->cookiegroups as $cookiegroup) {
+		$output .= '<div class="iwcc-cookiegroup-title iwcc-headline">';
+		$output .= $cookiegroup['name'].' <span>('.count($cookiegroup['cookie_uids']).')</span>';
+		$output .= '</div>';
+		$output .= '<div class="iwcc-cookiegroup-description">';
+		$output .= $cookiegroup['description'];
+		$output .= '</div>';
+		$output .= '<div class="iwcc-cookiegroup">';
+		$output .= '<table class="iwcc-cookietable">';
+		$output .= '<tr>
+						<th class="iwcc-cookie-name">'.$iwcc->texts['cookiename'].'</th>
+						<th class="iwcc-cookie-provider">'.$iwcc->texts['provider'].'</th>
+						<th class="iwcc-cookie-description">'.$iwcc->texts['usage'].'</th>
+						<th class="iwcc-cookie-lifetime">'.$iwcc->texts['lifetime'].'</th>
+						<th class="iwcc-cookie-service">'.$iwcc->texts['service'].'</th>
+					</tr>';
 		foreach ($cookiegroup['cookie_uids'] as $cookieUid) {
 			$cookie = $iwcc->cookies[$cookieUid];
 			foreach ($cookie['definition'] as $def) {
-				$cookieDatabase[$def['cookie_name']]=array(			
-					"service_name"=>$cookie['service_name'],
-					"provider"=>$cookie['provider'],
-					"category"=>$cookiegroup['name'],
-					"required"=>$cookiegroup['required'],
-					"lifetime"=>$def['cookie_lifetime'],
-					"description"=>$def['description']					
-				);
+				$output .= '<tr>';
+				$output .= '<td class="iwcc-cookie-name">'.$def['cookie_name'].'</td>';		
+				$output .= '<td class="iwcc-cookie-provider"><a href="'.$cookie['provider_link_privacy'].'">'.$cookie['provider'].'</a></td>';
+				$output .= '<td class="iwcc-cookie-description">'.$def['description'].'</td>';
+				$output .= '<td class="iwcc-cookie-lifetime">'.$def['cookie_lifetime'].'</td>';
+				$output .= '<td class="iwcc-cookie-service">'.$cookie['service_name'].'</td>';
+				$output .= '</tr>';
 			}
 		}
+		$output .= '</table>';
+		$output .= '</div>';
 	}
 
-	$outputDatabase = '<table class="cookieInfoTable">';
-	$outputDatabase .= '<tr>
-							<th class="cookieName">'.$iwcc->texts['cookiename'].'</th>
-							<th class="cookieService">'.$iwcc->texts['service'].'</th>
-							<th class="cookieProvider">'.$iwcc->texts['provider'].'</th>
-							<th class="cookieLifetime">'.$iwcc->texts['lifetime'].'</th>
-							<th class="cookieDescription">'.$iwcc->texts['usage'].'</th>
-							<th class="cookieCategory">'.$iwcc->texts['category'].'</th>
-							<th class="cookieValue">'.$iwcc->texts['value'].'</th>
-						</tr>';
-
-	foreach ($_COOKIE as $cookieName => $cookieValue) {
-		$outputDatabase .= '<tr>';
-		$outputDatabase .= '<td class="cookieName">'.$cookieName.'</td>';
-		if (isset($cookieDatabase[$cookieName]) || array_key_exists($cookieName, $cookieDatabase)) {
-			$outputDatabase .= '<td class="cookieService">'.$cookieDatabase[$cookieName]['service_name'].'</td>';
-			$outputDatabase .= '<td class="cookieProvider">'.$cookieDatabase[$cookieName]['provider'].'</td>';
-			$outputDatabase .= '<td class="cookieLifetime">'.$cookieDatabase[$cookieName]['lifetime'].'</td>';
-			$outputDatabase .= '<td class="cookieDescription">'.$cookieDatabase[$cookieName]['description'].'</td>';
-			$outputDatabase .= '<td class="cookieCategory">'.$cookieDatabase[$cookieName]['category'].'</td>';	
-			$outputDatabase .= '<td class="cookieValue">'.$cookieValue.'</td>';
+	// Cookies actually used
+	
+	$output .= '<hr>';
+	$output .= '<h2>'.$iwcc->texts['headline_usedcookies'].'</h2>';
+	
+	foreach ($iwcc->cookies as $cookies) {
+		foreach ($cookies['definition'] as $def) {
+			$cookiedb[$def['cookie_name']] = array(			
+				"service_name"=>$cookies['service_name'],
+				"provider"=>$cookies['provider'],
+				"lifetime"=>$def['cookie_lifetime'],
+				"description"=>$def['description']					
+			);
+		}
+	}
+	
+	$output .= '<div class="iwcc-cookiegroup">';
+	$output .= '<table class="iwcc-cookietable">';
+	$output .= '<tr>
+						<th class="iwcc-cookie-name">'.$iwcc->texts['cookiename'].'</th>
+						<th class="iwcc-cookie-provider">'.$iwcc->texts['provider'].'</th>
+						<th class="iwcc-cookie-description">'.$iwcc->texts['usage'].'</th>
+						<th class="iwcc-cookie-lifetime">'.$iwcc->texts['lifetime'].'</th>
+						<th class="iwcc-cookie-service">'.$iwcc->texts['service'].'</th>
+				</tr>';
+	foreach ($_COOKIE as $cookiename => $cookieValue) {
+		$output .= '<tr>';
+		$output .= '<td class="iwcc-cookie-name">'.$cookiename.'</td>';		
+		if (isset($cookiedb[$cookiename]) || array_key_exists($cookiename, $cookiedb)) {
+			$output .= '<td class="iwcc-cookie-provider">'.$cookiedb[$cookiename]['provider'].'</td>';
+			$output .= '<td class="iwcc-cookie-description">'.$cookiedb[$cookiename]['description'].'</td>';
+			$output .= '<td class="iwcc-cookie-lifetime">'.$cookiedb[$cookiename]['lifetime'].'</td>';
+			$output .= '<td class="iwcc-cookie-service">'.$cookiedb[$cookiename]['service_name'].'</td>';
 		}
 		else {
-			$outputDatabase .= '<td colspan="6">'.$iwcc->texts['missingdescription'].'</td>';
+			$output .= '<td colspan="4">'.$iwcc->texts['missingdescription'].'</td>';
 		}
-		$outputDatabase .= '</tr>';
+		$output .= '</tr>';
 	}
+	$output .= '</table>';
+	$output .= '</div>';
 
-	$outputDatabase .= '</table>';
-
-	echo $outputDatabase;
+	echo $output;
 
 }

--- a/fragments/iwcc_cookiedb.php
+++ b/fragments/iwcc_cookiedb.php
@@ -1,0 +1,61 @@
+<?php
+$iwcc = new iwcc_frontend($this->getVar('forceCache'));
+$iwcc->setDomain($_SERVER['HTTP_HOST']);
+if ($this->getVar('debug'))
+{
+	print_r($_COOKIE);
+}
+
+if ($iwcc->cookiegroups) {
+
+	$cookieDatabase = array();
+	
+	foreach ($iwcc->cookiegroups as $cookiegroup) {
+		foreach ($cookiegroup['cookie_uids'] as $cookieUid) {
+			$cookie = $iwcc->cookies[$cookieUid];
+			foreach ($cookie['definition'] as $def) {
+				$cookieDatabase[$def['cookie_name']]=array(			
+					"service_name"=>$cookie['service_name'],
+					"provider"=>$cookie['provider'],
+					"category"=>$cookiegroup['name'],
+					"required"=>$cookiegroup['required'],
+					"lifetime"=>$def['cookie_lifetime'],
+					"description"=>$def['description']					
+				);
+			}
+		}
+	}
+
+	$outputDatabase = '<table class="cookieInfoTable">';
+	$outputDatabase .= '<tr>
+							<th class="cookieName">'.$iwcc->texts['cookiename'].'</th>
+							<th class="cookieService">'.$iwcc->texts['service'].'</th>
+							<th class="cookieProvider">'.$iwcc->texts['provider'].'</th>
+							<th class="cookieLifetime">'.$iwcc->texts['lifetime'].'</th>
+							<th class="cookieDescription">'.$iwcc->texts['usage'].'</th>
+							<th class="cookieCategory">'.$iwcc->texts['category'].'</th>
+							<th class="cookieValue">'.$iwcc->texts['value'].'</th>
+						</tr>';
+
+	foreach ($_COOKIE as $cookieName => $cookieValue) {
+		$outputDatabase .= '<tr>';
+		$outputDatabase .= '<td class="cookieName">'.$cookieName.'</td>';
+		if (isset($cookieDatabase[$cookieName]) || array_key_exists($cookieName, $cookieDatabase)) {
+			$outputDatabase .= '<td class="cookieService">'.$cookieDatabase[$cookieName]['service_name'].'</td>';
+			$outputDatabase .= '<td class="cookieProvider">'.$cookieDatabase[$cookieName]['provider'].'</td>';
+			$outputDatabase .= '<td class="cookieLifetime">'.$cookieDatabase[$cookieName]['lifetime'].'</td>';
+			$outputDatabase .= '<td class="cookieDescription">'.$cookieDatabase[$cookieName]['description'].'</td>';
+			$outputDatabase .= '<td class="cookieCategory">'.$cookieDatabase[$cookieName]['category'].'</td>';	
+			$outputDatabase .= '<td class="cookieValue">'.$cookieValue.'</td>';
+		}
+		else {
+			$outputDatabase .= '<td colspan="6">'.$iwcc->texts['missingdescription'].'</td>';
+		}
+		$outputDatabase .= '</tr>';
+	}
+
+	$outputDatabase .= '</table>';
+
+	echo $outputDatabase;
+
+}

--- a/fragments/iwcc_cookiedb.php
+++ b/fragments/iwcc_cookiedb.php
@@ -34,17 +34,17 @@ if ($iwcc->cookiegroups) {
 		$consents_uids_output = implode(', ', $consents_service_names);
 		
 		$output .= '<h2>'.$iwcc->texts['headline_currentconsent'].'</h2>';
-		$output .= '<p class="iwcc-hisotry-date"><span>'.$iwcc->texts['consent_date'].':</span> '.$history[0]['createdate'].'</p>';		
-		$output .= '<p class="iwcc-hisotry-id"><span>'.$iwcc->texts['consent_id'].':</span> '.$history[0]['consentid'].'</p>';
-		$output .= '<p class="iwcc-hisotry-consents"><span>'.$iwcc->texts['consent_consents'].':</span> '.$consents_uids_output.'</p>';
+		$output .= '<p class="iwcc-history-date"><span>'.$iwcc->texts['consent_date'].':</span> '.$history[0]['createdate'].'</p>';		
+		$output .= '<p class="iwcc-history-id"><span>'.$iwcc->texts['consent_id'].':</span> '.$history[0]['consentid'].'</p>';
+		$output .= '<p class="iwcc-history-consents"><span>'.$iwcc->texts['consent_consents'].':</span> '.$consents_uids_output.'</p>';
 		$output .= '<p><a class="iwcc-show-box">'.$iwcc->texts['edit_consent'].'</a></p>'; // mit iwcc-show-box-reload funktionierts nicht korrekt
 		
 		$output .= '<h2>'.$iwcc->texts['headline_historyconsent'].'</h2>';
 		$output .= '<table class="iwcc-historytable">';
 		$output .= '<tr>
-						<th class="iwcc-hisotry-date">'.$iwcc->texts['consent_date'].'</th>
-						<th class="iwcc-hisotry-id">'.$iwcc->texts['consent_id'].'</th>
-						<th class="iwcc-hisotry-consents">'.$iwcc->texts['consent_consents'].'</th>
+						<th class="iwcc-history-date">'.$iwcc->texts['consent_date'].'</th>
+						<th class="iwcc-history-id">'.$iwcc->texts['consent_id'].'</th>
+						<th class="iwcc-history-consents">'.$iwcc->texts['consent_consents'].'</th>
 					</tr>';
 		foreach ($history as $historyentry) {	
 			$consents = json_decode($historyentry['consents']);
@@ -55,9 +55,9 @@ if ($iwcc->cookiegroups) {
 			}
 			$consents_uids_output = implode(', ', $consents_service_names);
 			$output .= '<tr>';
-			$output .= '<td class="iwcc-hisotry-date">'.$historyentry['createdate'].'</td>';		
-			$output .= '<td class="iwcc-hisotry-id">'.$historyentry['consentid'].'</td>';
-			$output .= '<td class="iwcc-hisotry-consents">'.$consents_uids_output.'</td>';
+			$output .= '<td class="iwcc-history-date">'.$historyentry['createdate'].'</td>';		
+			$output .= '<td class="iwcc-history-id">'.$historyentry['consentid'].'</td>';
+			$output .= '<td class="iwcc-history-consents">'.$consents_uids_output.'</td>';
 			$output .= '</tr>';
 		}
 		$output .= '</table>';

--- a/install.sql
+++ b/install.sql
@@ -6,4 +6,10 @@ INSERT IGNORE INTO `rex_iwcc_text` (`pid`, `id`, `clang_id`, `uid`, `text`) VALU
 (5, 5, 1, 'link_privacy', 'Datenschutzerklärung'),
 (6, 6, 1, 'lifetime', 'Laufzeit:'),
 (7, 7, 1, 'button_accept', 'Auswahl bestätigen'),
-(8, 8, 1, 'button_select_all', 'Alle auswählen');
+(8, 8, 1, 'button_select_all', 'Alle auswählen'),
+(9, 9, 1, 'cookiename', 'Cookie-Name:'),
+(10, 10, 1, 'usage', 'Service:'),
+(11, 11, 1, 'usage', 'Verwendungszweck:'),
+(12, 12, 1, 'category', 'Kategorie:'),
+(13, 13, 1, 'value', 'Wert:'),
+(14, 14, 1, 'missingdescription', 'Keine Informationen vorhanden');

--- a/install.sql
+++ b/install.sql
@@ -8,7 +8,7 @@ INSERT IGNORE INTO `rex_iwcc_text` (`pid`, `id`, `clang_id`, `uid`, `text`) VALU
 (7, 7, 1, 'button_accept', 'Auswahl bestätigen'),
 (8, 8, 1, 'button_select_all', 'Alle auswählen'),
 (9, 9, 1, 'cookiename', 'Cookie-Name:'),
-(10, 10, 1, 'usage', 'Service:'),
+(10, 10, 1, 'service', 'Service:'),
 (11, 11, 1, 'usage', 'Verwendungszweck:'),
 (12, 12, 1, 'category', 'Kategorie:'),
 (13, 13, 1, 'value', 'Wert:'),

--- a/install.sql
+++ b/install.sql
@@ -12,4 +12,12 @@ INSERT IGNORE INTO `rex_iwcc_text` (`pid`, `id`, `clang_id`, `uid`, `text`) VALU
 (11, 11, 1, 'usage', 'Verwendungszweck:'),
 (12, 12, 1, 'category', 'Kategorie:'),
 (13, 13, 1, 'value', 'Wert:'),
-(14, 14, 1, 'missingdescription', 'Keine Informationen vorhanden');
+(14, 14, 1, 'missingdescription', 'Keine Informationen vorhanden'),
+(15, 15, 1, 'headline_usedcookies', 'Aktuell verwendet diese Website folgende Cookies'),
+(16, 16, 1, 'headline_mayusedcookies', 'Cookies, die diese Website verwenden kann'),
+(17, 17, 1, 'headline_currentconsent', 'Ihre aktuelle Einwilligung'),
+(18, 18, 1, 'headline_historyconsent', 'Ihr Einwilligungs-Verlauf'),
+(19, 19, 1, 'consent_date', 'Einwilligungsdatum'),
+(20, 20, 1, 'consent_id', 'Einwilligungs-ID'),
+(21, 21, 1, 'consent_consents', 'Einwilligungen'),
+(22, 22, 1, 'edit_consent', 'Cookie Einstellungen bearbeiten');

--- a/lib/iwcc_frontend.php
+++ b/lib/iwcc_frontend.php
@@ -26,13 +26,13 @@ class iwcc_frontend
         $this->version = $this->cache['majorVersion'];
     }
 
-    public static function getFragment($debug, $forceCache)
+    public static function getFragment($debug, $forceCache, $fragmentFilename)
     {
         $fragment = new rex_fragment();
         $fragment->setVar('debug', $debug);
         $fragment->setVar('forceCache', $forceCache);
 
-        return $fragment->parse('iwcc_box.php');
+        return $fragment->parse($fragmentFilename);
     }
 
     public function setDomain($domain)

--- a/lib/rex_var_cookiedb.php
+++ b/lib/rex_var_cookiedb.php
@@ -1,11 +1,11 @@
 <?php
 
-class rex_var_iwcc extends rex_var
+class rex_var_cookiedb extends rex_var
 {
     protected function getOutput()
     {
         $debug = $this->getArg('debug', 0, false);
         $forceCache = $this->getArg('forceCache', 0, false);
-        return "iwcc_frontend::getFragment($debug,$forceCache,'iwcc_box.php')";
+        return "iwcc_frontend::getFragment($debug,$forceCache,'iwcc_cookiedb.php')";
     }
 }

--- a/setup/setup.sql
+++ b/setup/setup.sql
@@ -24,4 +24,10 @@ INSERT INTO `rex_iwcc_text` (`pid`, `id`, `clang_id`, `uid`, `text`) VALUES
 (5, 5, 1, 'link_privacy', 'Datenschutzerklärung'),
 (6, 6, 1, 'lifetime', 'Laufzeit:'),
 (7, 7, 1, 'button_accept', 'Auswahl bestätigen'),
-(8, 8, 1, 'button_select_all', 'Alle auswählen');
+(8, 8, 1, 'button_select_all', 'Alle auswählen'),
+(9, 9, 1, 'cookiename', 'Cookie-Name:'),
+(10, 10, 1, 'usage', 'Service:'),
+(11, 11, 1, 'usage', 'Verwendungszweck:'),
+(12, 12, 1, 'category', 'Kategorie:'),
+(13, 13, 1, 'value', 'Wert:'),
+(14, 14, 1, 'missingdescription', 'Keine Informationen vorhanden');

--- a/setup/setup.sql
+++ b/setup/setup.sql
@@ -26,7 +26,7 @@ INSERT INTO `rex_iwcc_text` (`pid`, `id`, `clang_id`, `uid`, `text`) VALUES
 (7, 7, 1, 'button_accept', 'Auswahl bestätigen'),
 (8, 8, 1, 'button_select_all', 'Alle auswählen'),
 (9, 9, 1, 'cookiename', 'Cookie-Name:'),
-(10, 10, 1, 'usage', 'Service:'),
+(10, 10, 1, 'service', 'Service:'),
 (11, 11, 1, 'usage', 'Verwendungszweck:'),
 (12, 12, 1, 'category', 'Kategorie:'),
 (13, 13, 1, 'value', 'Wert:'),

--- a/setup/setup.sql
+++ b/setup/setup.sql
@@ -30,4 +30,12 @@ INSERT INTO `rex_iwcc_text` (`pid`, `id`, `clang_id`, `uid`, `text`) VALUES
 (11, 11, 1, 'usage', 'Verwendungszweck:'),
 (12, 12, 1, 'category', 'Kategorie:'),
 (13, 13, 1, 'value', 'Wert:'),
-(14, 14, 1, 'missingdescription', 'Keine Informationen vorhanden');
+(14, 14, 1, 'missingdescription', 'Keine Informationen vorhanden'),
+(15, 15, 1, 'headline_usedcookies', 'Aktuell verwendet diese Website folgende Cookies'),
+(16, 16, 1, 'headline_mayusedcookies', 'Cookies, die diese Website verwenden kann'),
+(17, 17, 1, 'headline_currentconsent', 'Ihre aktuelle Einwilligung'),
+(18, 18, 1, 'headline_historyconsent', 'Ihr Einwilligungs-Verlauf'),
+(19, 19, 1, 'consent_date', 'Einwilligungsdatum'),
+(20, 20, 1, 'consent_id', 'Einwilligungs-ID'),
+(21, 21, 1, 'consent_consents', 'Einwilligungen'),
+(22, 22, 1, 'edit_consent', 'Cookie Einstellungen bearbeiten');


### PR DESCRIPTION
Über den Aufruf von REX_COOKIEDB[] können alle derzeit gesetzten Cookies z.B. in der Datenschutzerklärung ausgegeben werden. Die Infos zu den Cookies stammen dabei aus iwcc.

(2ter Versuch)

#62 